### PR TITLE
Fix player breaking when `starting_playlist_song is '0'`

### DIFF
--- a/src/init/init.js
+++ b/src/init/init.js
@@ -509,12 +509,12 @@ let Initializer = (function() {
     initializeElements();
 
     /*
-			If the user has selected a starting playlist, we need to set the starting playlist
-			and sync the visuals
+			If the user has selected a starting playlist, we need to check whether it is a valid starting playlist and if so
+			set the starting playlist and sync the visuals
 		*/
     if (
-      userConfig.starting_playlist != undefined &&
-      userConfig.starting_playlist != ""
+      typeof userConfig.starting_playlist !== 'undefined' &&
+      userConfig.playlists.hasOwnProperty(userConfig.starting_playlist)
     ) {
       /*
 				Set the active playlist to the starting playlist by the user
@@ -522,57 +522,38 @@ let Initializer = (function() {
       config.active_playlist = userConfig.starting_playlist;
 
       /*
-				Check if the user defined a song to start with in the playlist.
+				Check if the user defined a valid song to start with in the playlist.
 			*/
       if (
-        userConfig.starting_playlist_song != undefined &&
-        userConfig.starting_playlist_song != ""
+        typeof userConfig.starting_playlist_song !== 'undefined' &&
+        !isNaN(parseInt(userConfig.starting_playlist_song)) &&
+        userConfig.playlists[userConfig.starting_playlist].songs.hasOwnProperty(parseInt(userConfig.starting_playlist_song))
       ) {
         /*
-					Ensure the song is a valid index.
-				*/
-        if (
-          typeof userConfig.playlists[userConfig.starting_playlist].songs[
+          Set the player to the song defined by the user.
+        */
+        AudioNavigation.changeSongPlaylist(
+          config.active_playlist,
+          userConfig.playlists[userConfig.starting_playlist].songs[
             parseInt(userConfig.starting_playlist_song)
-          ] != undefined
-        ) {
-          /*
-						Set the player to the song defined by the user.
-					*/
-          AudioNavigation.changeSongPlaylist(
-            config.active_playlist,
-            userConfig.playlists[userConfig.starting_playlist].songs[
-              parseInt(userConfig.starting_playlist_song)
-            ],
-            parseInt(userConfig.starting_playlist_song)
-          );
-        } else {
-          /*
-						Set the player to the first song in the playlist
-					*/
-          AudioNavigation.changeSongPlaylist(
-            config.active_playlist,
-            userConfig.playlists[userConfig.starting_playlist].songs[0],
-            0
-          );
-          /*
-						Debug that the song index doesn't exist
-					*/
-          Debug.writeMessage(
-            "The index of " +
-              userConfig.starting_playlist_song +
-              " does not exist in the playlist " +
-              userConfig.starting_playlist
-          );
-        }
+          ],
+          parseInt(userConfig.starting_playlist_song)
+        );
       } else {
         /*
-					Set the player to the first song in the playlist
-				*/
-        AudioNavigation.changeSong(
+          Set the player to the first song in the playlist
+        */
+        AudioNavigation.changeSongPlaylist(
           config.active_playlist,
           userConfig.playlists[userConfig.starting_playlist].songs[0],
           0
+        );
+
+        /*
+          Debug that the song index doesn't exist
+        */
+        Debug.writeMessage(
+          `The index of ${userConfig.starting_playlist_song} does not exist in the playlist ${userConfig.starting_playlist}. Setting index to 0.`
         );
       }
 
@@ -580,6 +561,13 @@ let Initializer = (function() {
 				Sync the main and song play pause buttons.
 			*/
       PlayPauseElements.sync();
+    } else {
+      /*
+        Debug that the song index doesn't exist
+			*/
+      Debug.writeMessage(
+        `The playlist ${userConfig.starting_playlist} could not be found, and thus was not set as your starting playlist.`
+      );
     }
 
     /*

--- a/tests/playlist/init.test.js
+++ b/tests/playlist/init.test.js
@@ -1,0 +1,105 @@
+const Amplitude = require("../../src/index.js");
+
+const config = require("../../src/config.js");
+
+const Setup = require("../setup.js");
+
+const additionalConfig = {
+  starting_playlist: 'ancient_astronauts',
+  starting_playlist_song: 0,
+}
+
+beforeEach(() => {
+  Setup.initializeTestingElement();
+});
+
+afterEach(() => {
+  Setup.resetConfig();
+});
+
+test("AmplitudeJS Initializes active Playlists Correctly when a valid playlist is supplied", () => {
+  Setup.initializeAmplitude({
+    starting_playlist: 'ancient_astronauts',
+    starting_playlist_song: 0,
+  });
+
+  expect(Amplitude.getActivePlaylist()).toBe('ancient_astronauts');
+});
+
+test("AmplitudeJS Initializes no active Playlists when an invalid playlist is supplied", () => {
+  Setup.initializeAmplitude({
+    starting_playlist: 'not_a_valid_playlist',
+    starting_playlist_song: 0,
+  });
+
+  expect(Amplitude.getActivePlaylist()).toBe(null);
+});
+
+test("AmplitudeJS Initializes no active Playlists when no playlist is supplied", () => {
+  Setup.initializeAmplitude();
+
+  expect(Amplitude.getActivePlaylist()).toBe(null);
+});
+
+test("AmplitudeJS Initializes Playlists `active_index` Correctly with an integer value of `0` as `starting_playlist_song`", () => {
+  Setup.initializeAmplitude({
+    starting_playlist: 'ancient_astronauts',
+    starting_playlist_song: 0,
+  });
+
+  expect(Amplitude.getActivePlaylistMetadata().active_index).toBe(0);
+});
+
+test("AmplitudeJS Initializes Playlists `active_index` Correctly with an integer as `starting_playlist_song`", () => {
+  Setup.initializeAmplitude({
+    starting_playlist: 'ancient_astronauts',
+    starting_playlist_song: 1,
+  });
+
+  expect(Amplitude.getActivePlaylistMetadata().active_index).toBe(1);
+});
+
+test("AmplitudeJS Initializes Playlists `active_index` Correctly with a string as `starting_playlist_song`", () => {
+  Setup.initializeAmplitude({
+    starting_playlist: 'ancient_astronauts',
+    starting_playlist_song: '1',
+  });
+
+  expect(Amplitude.getActivePlaylistMetadata().active_index).toBe(1);
+});
+
+test("AmplitudeJS Initializes Playlists with an index of 0 when no `starting_playlist_song` is supplied", () => {
+  Setup.initializeAmplitude({
+    starting_playlist: 'ancient_astronauts'
+  });
+
+  expect(Amplitude.getActivePlaylist()).toBe('ancient_astronauts');
+  expect(Amplitude.getActivePlaylistMetadata().active_index).toBe(0);
+});
+
+test("AmplitudeJS Initializes Playlists `active_index` with `0` when an invalid `starting_playlist_song` is supplied", () => {
+  Setup.initializeAmplitude({
+    starting_playlist: 'ancient_astronauts',
+    starting_playlist_song: 2, // Outside of the playlist song array, which contains only two songs
+  });
+
+  expect(Amplitude.getActivePlaylistMetadata().active_index).toBe(0);
+
+  Setup.resetConfig();
+
+  Setup.initializeAmplitude({
+    starting_playlist: 'ancient_astronauts',
+    starting_playlist_song: -1, // Generally no valid array index
+  });
+
+  expect(Amplitude.getActivePlaylistMetadata().active_index).toBe(0);
+
+  Setup.resetConfig();
+
+  Setup.initializeAmplitude({
+    starting_playlist: 'ancient_astronauts',
+    starting_playlist_song: '', // Not a Number
+  });
+
+  expect(Amplitude.getActivePlaylistMetadata().active_index).toBe(0);
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -5,8 +5,8 @@ const BarVisualization = require("../dist/visualizations/bar.js");
 const config = require("../src/config.js");
 
 let Setup = (function() {
-  function initializeAmplitude() {
-    Amplitude.init({
+  function initializeAmplitude(additionalConfig = {}) {
+    Amplitude.init(Object.assign({
       bindings: {
         37: "prev",
         39: "next",
@@ -149,7 +149,7 @@ let Setup = (function() {
           }
         }
       ]
-    });
+    }, additionalConfig));
 
     config.audio.currentTime = 30;
     config.audio.duration = 100;
@@ -244,92 +244,59 @@ let Setup = (function() {
     });
   }
 
-  function resetConfig() {
-    config.audio = new Audio();
+  function resetConfig(additionalConfig = {}) {
 
-    config.active_metadata = {};
+    let defaultConfig = {
+      audio: new Audio(),
+      active_metadata: {},
+      active_album: "",
+      active_index: 0,
+      active_playlist: "",
+      autoplay: false,
+      playback_speed: 1.0,
+      callbacks: {},
+      songs: [],
+      playlists: {},
+      start_song: "",
+      starting_playlist: "",
+      starting_playlist_song: "",
+      repeat: false,
+      repeat_song: false,
+      shuffle_list: {},
+      shuffle_on: false,
+      default_album_art: "",
+      default_playlist_art: "",
+      debug: false,
+      volume: 0.5,
+      pre_mute_volume: 0.5,
+      volume_increment: 5,
+      volume_decrement: 5,
+      soundcloud_client: "",
+      soundcloud_use_art: false,
+      soundcloud_song_count: 0,
+      soundcloud_songs_ready: 0,
+      is_touch_moving: false,
+      buffered: 0,
+      bindings: {},
+      continue_next: true,
+      delay: 0,
+      player_state: "stopped",
+      web_audio_api_available: false,
+      context: null,
+      source: null,
+      analyser: null,
+      visualizations: {
+        available: [],
+        active: [],
+        backup: "",
+      },
+      waveforms: {
+        sample_rate: 100,
+        built: [],
+      }
+    };
 
-    config.active_album = "";
-
-    config.active_index = 0;
-
-    config.active_playlist = "";
-
-    config.autoplay = false;
-
-    config.playback_speed = 1.0;
-
-    config.callbacks = {};
-
-    config.songs = [];
-
-    config.playlists = {};
-
-    config.start_song = "";
-
-    config.starting_playlist = "";
-
-    config.starting_playlist_song = "";
-
-    config.repeat = false;
-
-    config.repeat_song = false;
-
-    config.shuffle_list = {};
-
-    config.shuffle_on = false;
-
-    config.default_album_art = "";
-
-    config.default_playlist_art = "";
-
-    config.debug = false;
-
-    config.volume = 0.5;
-
-    config.pre_mute_volume = 0.5;
-
-    config.volume_increment = 5;
-
-    config.volume_decrement = 5;
-
-    config.soundcloud_client = "";
-
-    config.soundcloud_use_art = false;
-
-    config.soundcloud_song_count = 0;
-
-    config.soundcloud_songs_ready = 0;
-
-    config.is_touch_moving = false;
-
-    config.buffered = 0;
-
-    config.bindings = {};
-
-    config.continue_next = true;
-
-    config.delay = 0;
-
-    config.player_state = "stopped";
-
-    config.web_audio_api_available = false;
-
-    config.context = null;
-
-    config.source = null;
-
-    config.analyser = null;
-
-    config.visualizations.available = [];
-
-    config.visualizations.active = [];
-
-    config.visualizations.backup = "";
-
-    config.waveforms.sample_rate = 100;
-
-    config.waveforms.built = [];
+    Object.assign(config, defaultConfig, additionalConfig);
   }
 
   return {


### PR DESCRIPTION
As mentioned in #407 the player breaks and is unusable, when supplying a `starting_playlist_song` that is `(int) 0`.

To alleviate this issue, I adapted the way playlists get initialized and covered my chagnes with tests.

### What has changed?

Basically, we now check more closely if the supplied values for `starting_playlist` and `starting_playlist_song` are valid. We not check their type and value, but also validate them against the playlist data. So an non existing `starting_playlist_song` index is as invalid as a `NaN` for example.

### What was adapted to make this change possible?

In order to write tests that could check a larger variety of cases, I needed to adapt the way test data was initalized, so that I could supply my own values. I also adapted the function that resets the configuration after each test in a similar way. But in hind sight that was not necessary.

The newly added test are partially redundant with some existing ones that check the initialization of the playlists. Also I think it might make sense to move all playlist tests from the `tests/index.test.js` file to the newly added `tests/playlist/init.test.js` file for an easier to graps structure. But I didn't want to change things around so much without asking. If requested I'll move the playlist tests as mentioned.


More details can be found in the commit messages.

