### PR TITLE
Prototype pollution in metadata setter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1150,7 +1150,9 @@ let Amplitude = (function() {
       for (var key in metaData) {
         if (metaData.hasOwnProperty(key)) {
           if (key != "url" && key != "URL" && key != "live" && key != "LIVE") {
-            config.playlists[playlist].songs[index][key] = metaData[key];
+            if (config.playlists[playlist].songs.hasOwnProperty(index)) {
+              config.playlists[playlist].songs[index][key] = metaData[key];
+            }
           }
         }
       }
@@ -1161,7 +1163,9 @@ let Amplitude = (function() {
       for (var key in metaData) {
         if (metaData.hasOwnProperty(key)) {
           if (key != "url" && key != "URL" && key != "live" && key != "LIVE") {
-            config.songs[index][key] = metaData[key];
+            if (config.songs.hasOwnProperty(index)) {
+              config.songs[index][key] = metaData[key];
+            }
           }
         }
       }
@@ -1185,7 +1189,9 @@ let Amplitude = (function() {
       for (var key in metaData) {
         if (metaData.hasOwnProperty(key)) {
           if (ignoredKeys.indexOf(key) < 0) {
-            config.playlists[playlist][key] = metaData[key];
+            if (config.playlists.hasOwnProperty(playlist)) {
+              config.playlists[playlist][key] = metaData[key];
+            }
           }
         }
       }


### PR DESCRIPTION
Hi there, I found a potential prototype pollution in the metadata setter `setSongMetaData` and `setPlaylistMetaData` under some specific condition.

Here is the sample code:

```js
let obj = {};
Amplitude.addPlaylist("__proto__", {}, []);
Amplitude.setPlaylistMetaData("__proto__", { a: "pollution" });
console.log(obj.a); // output: pollution
```

Expected behaviour: `obj.a` should be `undefined`.

