### PR TITLE
fire "change" event when set value of songSlider input element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "amplitudejs",
-      "version": "5.3.0",
+      "version": "5.3.2",
       "license": "MIT",
       "devDependencies": {
         "babel-core": "^6.26.3",
@@ -3757,7 +3757,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -4609,8 +4608,7 @@
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6001,8 +5999,7 @@
       "dependencies": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "source-map": "^0.6.1"
       },
       "bin": {
         "handlebars": "bin/handlebars"
@@ -10631,7 +10628,6 @@
         "capture-exit": "^1.2.0",
         "exec-sh": "^0.2.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
         "minimist": "^1.1.1",
         "walker": "~1.0.5",
@@ -13128,7 +13124,6 @@
       "dev": true,
       "dependencies": {
         "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
         "yargs": "~3.10.0"
       },
       "bin": {

--- a/src/visual/songSliderElements.js
+++ b/src/visual/songSliderElements.js
@@ -59,6 +59,7 @@ let SongSliderElements = (function() {
       */
       if (playlist == null && song == null) {
         mainSongSliders[i].value = location;
+        mainSongSliders[i].dispatchEvent(new Event("change"));
       }
     }
   }
@@ -105,6 +106,7 @@ let SongSliderElements = (function() {
 			*/
       if (playlistAttribute == playlist && songAttribute == null) {
         playlistSongSliders[i].value = location;
+        playlistSongSliders[i].dispatchEvent(new Event("change"));
       }
     }
   }
@@ -155,6 +157,7 @@ let SongSliderElements = (function() {
 				*/
         if (playlistAttribute == null && songAttribute == songIndex) {
           songSliders[i].value = location;
+          songSliders[i].dispatchEvent(new Event("change"));
         }
       }
     }
@@ -195,6 +198,7 @@ let SongSliderElements = (function() {
 		*/
     for (let i = 0; i < songInPlaylistSliders.length; i++) {
       songInPlaylistSliders[i].value = location;
+      songInPlaylistSliders[i].dispatchEvent(new Event("change"));
     }
   }
 
@@ -213,6 +217,7 @@ let SongSliderElements = (function() {
 		*/
     for (let i = 0; i < songSliders.length; i++) {
       songSliders[i].value = 0;
+      songSliders[i].dispatchEvent(new Event("change"));
     }
   }
 
@@ -225,7 +230,7 @@ let SongSliderElements = (function() {
     syncPlaylist: syncPlaylist,
     syncSong: syncSong,
     syncSongInPlaylist: syncSongInPlaylist,
-    resetElements: resetElements
+    resetElements: resetElements,
   };
 })();
 

--- a/tests/visual/songSliderElements.test.js
+++ b/tests/visual/songSliderElements.test.js
@@ -84,3 +84,26 @@ test("AmplitudeJS Song Slider Elements adjust current Time For Song", () => {
   );
   expect(document.getElementById("individual-song-slider").value).toBe("45");
 });
+
+test("AmplitudeJS Song Slider Elements trigger change event when value changed", () => {
+  Amplitude.playSongAtIndex(2);
+
+  const songSliderEl = document.getElementById("global-song-slider");
+
+  let onChangeCalled = false;
+  function onChangeCallback() {
+    onChangeCalled = true;
+  }
+  songSliderEl.addEventListener("change", onChangeCallback);
+  config.audio.currentTime = 45;
+  SongSliderElements.sync(
+    config.audio.currentTime,
+    config.active_playlist,
+    config.active_playlist != "" && config.active_playlist != null
+      ? config.playlists[config.active_playlist].active_index
+      : config.active_index
+  );
+
+  expect(document.getElementById("individual-song-slider").value).toBe("45");
+  expect(onChangeCalled).toBe(true);
+});


### PR DESCRIPTION
Hi.
It would be beneficial to trigger the "change" event when modifying the value attribute of the `songSlider` input element. This feature is particularly useful for customizing the UI and using alternative elements instead of the default input. By binding an event listener to the `change` event, such as `addEventListener("change", (e) => e.target.value)`, we can capture the modified values and update our custom UI elements accordingly.
